### PR TITLE
Wishbone ext

### DIFF
--- a/functionals_tests/apf6_wbextvalidation.pod
+++ b/functionals_tests/apf6_wbextvalidation.pod
@@ -1,0 +1,14 @@
+create apf6_wbextvalidation
+selectplatform standard.apf6_sp
+
+addinstance components.led.wb
+connectpin led00.int_led.led.0 apf6_sp.fpga.LED0
+
+autoconnectbus
+
+generateintercon imx6_wb_wrapper00.aval64
+generateintercon imx6_wb_wrapper00.candroutput
+generatetop
+synthesis.selecttoolchain quartus
+synthesis.generateproject
+synthesis.generatebitstream

--- a/functionals_tests/test_launcher.py
+++ b/functionals_tests/test_launcher.py
@@ -39,6 +39,15 @@ class test_launcher(unittest.TestCase):
         self.assertTrue(os.path.isfile("apf27uartgpio/objs/top_apf27uartgpio.bit"))
         os.system("rm -rf  apf27uartgpio")
 
+    def test_apf6_wbextvalidation(self):
+        """ testing apf6_wbextvaldation script"""
+        os.system("rm -rf  apf6_validation")
+        with self.assertRaises(SystemExit):
+            pod.main(['pod', '-s', 'functionals_tests/apf6_wbextvalidation.pod'])
+        self.assertTrue(os.path.isfile("apf6_wbextvalidation/binaries/top_test_apf6_wbextvalidation.core.rbf"))
+        self.assertTrue(os.path.isfile("apf6_wbextvalidation/binaries/top_test_apf6_wbextvalidation.periph.rbf"))
+        os.system("rm -rf  apf6_validation")
+
 
 if __name__ == "__main__":
     print "Functionnals tests launcher"

--- a/src/busses/wishboneExt/wishboneExt.py
+++ b/src/busses/wishboneExt/wishboneExt.py
@@ -355,6 +355,7 @@ def addressdecoding(masterinterface, masterinstancename, intercon):
             slaveinterface.name + "_cs"
         slavesizeaddr = slave.get_interface().addr_port_size
         slavebase_address = slaveinterface.base_addr
+        slavebase_size = int(math.log(int(slaveinterface.data_size) / 8, 2))
         if slavesizeaddr > 0:
             slaveaddressport = slave.get_interface().get_port_by_type(
                 bus.sig_name("slave", "address"))
@@ -362,11 +363,11 @@ def addressdecoding(masterinterface, masterinstancename, intercon):
                 slaveaddressport.name
 
         out = out + "\n"
-        out = out + ONETAB*3 + "if " + masteraddressname + "(" +\
-            str(int(mastersizeaddr-1)) + " downto " + str(slavesizeaddr + 1) +\
-            ')="' +\
+        out = out + ONETAB*3 + "if " + masteraddressname + "(" + \
+            str(int(mastersizeaddr-1)) + " downto " + \
+            str(slavesizeaddr + slavebase_size) + ')="' + \
             sy.inttobin(slavebase_address,
-                        int(mastersizeaddr))[:-(slavesizeaddr + 1)] +\
+                        int(mastersizeaddr))[:-(slavesizeaddr + slavebase_size)] +\
             '"' + " and " + masterstrobename + "='1' then\n"
 
         out = out + ONETAB * 4 + chipselectname + " <= '1';\n"

--- a/src/busses/wishboneExt/wishboneExt.py
+++ b/src/busses/wishboneExt/wishboneExt.py
@@ -89,10 +89,8 @@ def getListSize(masterinterface):
     for slave in masterinterface.slaves:
         for i in slave.get_instance().interfaces:
             if i.bus_name == "wishboneExt":
-                for p in i.ports:
-                    if p.porttype == "DAT_I":
-                        data_size.append(int(p.real_size))
-    return data_size
+                data_size.append(int(i.data_size))
+    return list(set(data_size))
 
 
 def architectureHead(masterinterface, intercon):

--- a/src/busses/wishboneExt/wishboneExt.py
+++ b/src/busses/wishboneExt/wishboneExt.py
@@ -312,7 +312,7 @@ def addressdecoding(masterinterface, masterinstancename, intercon):
     mastersizeaddr = masterinterface.addr_port_size
 
     out = ONETAB + "-----------------------\n"
-    out = "\n" + ONETAB + "-- Address decoding  --\n"
+    out = out + "\n" + ONETAB + "-- Address decoding  --\n"
     out = out + ONETAB + "-----------------------\n"
     for slave in masterinterface.slaves:
         slaveinstance = slave.get_instance()

--- a/src/busses/wishboneExt/wishboneExt.py
+++ b/src/busses/wishboneExt/wishboneExt.py
@@ -1,0 +1,564 @@
+#! /usr/bin/python
+# -*- coding: utf-8 -*-
+# ----------------------------------------------------------------------------
+# Name:     wishbone16.py
+# Purpose:
+# Author:   Gwenhael Goavec-Merou <gwenhael.goavec-merou@trabucayre.com>
+#           Fabien Marteau <fabien.marteau@armadeus.com>
+# Created:  22/07/2015
+# ----------------------------------------------------------------------------
+#  Copyright (2015)  Armadeus Systems
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+#
+# ----------------------------------------------------------------------------
+""" Manage wishbone data bus"""
+
+import time
+import datetime
+import math
+
+from periphondemand.bin.define import TEMPLATESPATH
+from periphondemand.bin.define import HEADERTPL
+from periphondemand.bin.define import VHDLEXT
+from periphondemand.bin.define import ONETAB
+from periphondemand.bin.define import COMPONENTSPATH
+from periphondemand.bin.define import HDLDIR
+
+from periphondemand.bin.utils.settings import Settings
+from periphondemand.bin.utils.poderror import PodError
+from periphondemand.bin.utils import wrappersystem as sy
+
+from periphondemand.bin.core.component import Component
+from periphondemand.bin.core.port import Port
+from periphondemand.bin.core.interface import Interface
+from periphondemand.bin.core.hdl_file import HdlFile
+
+SETTINGS = Settings()
+
+
+def header(author, intercon):
+    """ return vhdl header
+    """
+    header = open(SETTINGS.path + TEMPLATESPATH + "/" + HEADERTPL, "r").read()
+    header = header.replace("$tpl:author$", author)
+    header = header.replace("$tpl:date$", str(datetime.date.today()))
+    header = header.replace("$tpl:filename$", intercon.name + VHDLEXT)
+    header = header.replace("$tpl:abstract$", intercon.description)
+    return header
+
+
+def entity(intercon):
+    """ generate entity
+    """
+    entity = "Entity " + intercon.name + " is\n"
+    entity = entity + ONETAB + "port\n" + ONETAB + "(\n"
+    for interface in intercon.interfaces:
+        entity = entity + "\n" + ONETAB * 2 + "-- " +\
+            interface.name + " connection\n"
+        for port in interface.ports:
+            entity = entity + ONETAB * 2 + "%-40s" % port.name + " : " +\
+                "%-5s" % port.direction
+            if port.size == "1":
+                entity = entity + "std_logic;\n"
+            else:
+                entity = entity + "std_logic_vector(" + port.max_pin_num +\
+                    " downto " + port.min_pin_num + ");\n"
+    # Suppress the #!@ last semicolon
+    entity = entity[:-2]
+    entity = entity + "\n"
+
+    entity = entity + ONETAB + ");\n" + "end entity;\n\n"
+    return entity
+
+
+def getListSize(masterinterface):
+    data_size = []
+    for slave in masterinterface.slaves:
+        for i in slave.get_instance().interfaces:
+            if i.bus_name == "wishboneExt":
+                for p in i.ports:
+                    if p.porttype == "DAT_I":
+                        data_size.append(int(p.real_size))
+    return data_size
+
+
+def architectureHead(masterinterface, intercon):
+    """ Generate the head architecture
+    """
+    addr_size = masterinterface.get_port_by_type("ADR").max_pin_num
+    data_size = getListSize(masterinterface)
+    bus = masterinterface.bus
+    masterinstance = masterinterface.parent
+    masterinstancename = masterinstance.instancename
+
+    archead = "architecture " + intercon.name + "_1 of " +\
+        intercon.name + " is\n"
+
+    # create new data signal
+    for size in data_size:
+        archead = archead + ONETAB + "signal " +\
+            "%-20s" % ("writedata" + str(size) + "_s") + \
+            " : std_logic_vector(" + str(size-1) + " downto 0);\n"
+    archead = archead + ONETAB + "signal " + \
+        "%-20s" % ("wbm_address_s") + \
+        " : std_logic_vector(" + addr_size + " downto 0);\n"
+    data_size = int(masterinterface.data_size)-1
+    for slave in masterinterface.slaves:
+        archead = archead + ONETAB + "signal " +\
+            "%-20s" % (slave.instancename + "_" +
+                       slave.interfacename + "_cs") +\
+            " : std_logic := '0' ;\n"
+        archead = archead + ONETAB + "signal " +\
+            "%-20s" % (slave.instancename + "_readdata_s") + \
+            " : std_logic_vector(" + str(data_size) + " downto 0);\n"
+    archead = archead + "begin\n"
+    return archead
+
+
+def genCaseByteEnable(masterinterface):
+    out = ""
+    bus = masterinterface.bus
+
+    data_size = getListSize(masterinterface)
+
+    byte_en = masterinterface.get_port_by_type("BYE")
+    byte_en_name = masterinterface.parent.instancename + "_" + byte_en.name
+    byte_en_size = int(byte_en.real_size)
+    write_bus = masterinterface.get_port_by_type(
+        masterinterface.bus.sig_name("master", "dataout"))
+    write_bus_name = masterinterface.parent.instancename + "_" + \
+        write_bus.name
+    master_size = int(write_bus.real_size)
+    addr_inst = masterinterface.get_port_by_type(
+        masterinterface.bus.sig_name("master", "address"))
+    addr_bus = masterinterface.parent.instancename + "_" + addr_inst.name
+    addr_size = addr_inst.max_pin_num
+    shift = int(math.log(master_size / 8, 2))
+
+    masteraddressname = "wbm_address_s"
+
+    for size in data_size:
+        nb_byte = size / 8
+        mask = pow(2, nb_byte)-1
+
+        out = out + ONETAB + "writedata" + str(size) + "_s <= "
+
+        if int(size) == int(master_size):
+            out = out + write_bus_name
+        else:
+            bitsize = byte_en_size / nb_byte
+            for i in range(bitsize):
+                val = bin(int(mask * pow(2, nb_byte*i)))[2:]
+                out = out + write_bus_name + "(" + \
+                    str(((i+1) * size)-1) + " downto " + str(i * size) + ")"
+                if i < bitsize-1:
+                    out = out + ' when ' + byte_en_name + ' = "' + \
+                        val.zfill(byte_en_size) + '" else \n' + 2 * ONETAB
+        out = out + ";\n\n"
+
+    # addr reconstruct
+    if len(data_size) == 1 and data_size[0] == master_size:
+        out = out + ONETAB + masteraddressname + " <= " + addr_bus + ";\n"
+    else:
+        slave_addr = masteraddressname + "(" + str(shift-1) + " downto 0) <= "
+        out = out + ONETAB + masteraddressname + "(" + str(addr_size) + \
+            " downto " + str(shift) + ") <= " + \
+            addr_bus + "(" + str(addr_size) + " downto " + str(shift) + ");\n"
+        out = out + ONETAB + slave_addr
+        for size in data_size:
+            if not (int(size) == int(master_size)):
+                nb_byte = size / 8
+                mask = pow(2, nb_byte)-1
+                for i in range(byte_en_size / nb_byte):
+                    val = bin(int(mask * pow(2, nb_byte*i)))[2:]
+                    out = out + ' "' + \
+                        str(((bin(i*(size/8))[2:]).zfill(3))) + \
+                        '" when ' + byte_en_name + ' = "' + \
+                        val.zfill(byte_en_size) + '" else\n' + 2 * ONETAB
+
+        out = out + "(others => '0');\n"
+
+    return out
+
+
+def connectClockandReset(masterinterface, intercon):
+    """ Connect clock and reset
+    """
+
+    bus = masterinterface.bus
+    masterinstance = masterinterface.parent
+    masterinstancename = masterinstance.instancename
+    masterinterfacename = masterinterface.name
+    masterresetname = masterinstancename + "_" +\
+        masterinterface.get_port_by_type(
+            bus.sig_name("master", "reset")).name
+    masterclockname = masterinstancename + "_" +\
+        masterinterface.get_port_by_type(
+            bus.sig_name("master", "clock")).name
+    out = "\n" + ONETAB + "-- Clock and Reset connection\n"
+
+    for slave in masterinterface.slaves:
+        slaveinstance = slave.get_instance()
+        slaveinterface = slave.get_interface()
+        slaveinstancename = slave.instancename
+        slaveresetname = slaveinstancename + "_" +\
+            slaveinterface.get_port_by_type(
+                bus.sig_name("slave", "reset")).name
+        slaveclockname = slaveinstancename + "_" +\
+            slaveinterface.get_port_by_type(
+                bus.sig_name("slave", "clock")).name
+        # reset
+        out = out + ONETAB + slaveresetname + " <= " + masterresetname + ";\n"
+        # clock
+        out = out + ONETAB + slaveclockname + " <= " + masterclockname + ";\n"
+    return out
+
+
+def addressdecoding(masterinterface, masterinstancename, intercon):
+    """ generate VHDL for address decoding
+    """
+    bus = masterinterface.bus
+    masterinstance = masterinterface.parent
+    masterinstancename = masterinstance.instancename
+    rst_name = masterinstancename + "_" +\
+        masterinterface.get_port_by_type(
+            bus.sig_name("master", "reset")).name
+    clk_name = masterinstancename + "_" +\
+        masterinterface.get_port_by_type(
+            bus.sig_name("master", "clock")).name
+    masteraddressname = "wbm_address_s"
+    masterstrobename = masterinstancename + "_" +\
+        masterinterface.get_port_by_type(
+            bus.sig_name("master", "strobe")).name
+    mastersizeaddr = masterinterface.addr_port_size
+
+    out = ONETAB + "-----------------------\n"
+    out = "\n" + ONETAB + "-- Address decoding  --\n"
+    out = out + ONETAB + "-----------------------\n"
+    for slave in masterinterface.slaves:
+        slaveinstance = slave.get_instance()
+        slaveinterface = slave.get_interface()
+        slavesizeaddr = slave.get_interface().addr_port_size
+        slavebase_address = slaveinterface.base_addr
+        slavebase_size = int(math.log(int(slaveinterface.data_size) / 8, 2))
+
+        if slavesizeaddr > 0:
+            slaveaddressport = slave.get_interface().get_port_by_type(
+                bus.sig_name("slave", "address"))
+            slavename_addr = slaveinstance.instancename + "_" +\
+                slaveaddressport.name
+        if slavesizeaddr == 1:
+            out = out + ONETAB + slavename_addr +\
+                " <= " + masteraddressname + "(1);\n"
+        elif slavesizeaddr > 1:
+            out = out + ONETAB + slavename_addr + " <= " + masteraddressname +\
+                "(" + str(slavesizeaddr+slavebase_size-1) + " downto " + \
+                str(slavebase_size) + ");\n"
+    out = out + "\n"
+    out = out + ONETAB + "decodeproc : process(" + clk_name + ", " + rst_name +\
+        ", " + masteraddressname + ")\n"
+    out = out + ONETAB + "begin\n"
+
+    # initialize
+    out = out + ONETAB*2 + "if " + rst_name + "='1' then\n"
+    for slave in masterinterface.slaves:
+        slaveinstance = slave.get_instance()
+        slaveinterface = slave.get_interface()
+        chipselectname = slaveinstance.instancename + "_" +\
+            slaveinterface.name + "_cs"
+        out = out + ONETAB*3 + chipselectname + " <= '0';\n"
+    out = out + ONETAB*2 + "elsif rising_edge(" + clk_name + ") then\n"
+
+    for slave in masterinterface.slaves:
+        slaveinstance = slave.get_instance()
+        slaveinterface = slave.get_interface()
+        chipselectname = slaveinstance.instancename + "_" +\
+            slaveinterface.name + "_cs"
+        slavesizeaddr = slave.get_interface().addr_port_size
+        slavebase_address = slaveinterface.base_addr
+        if slavesizeaddr > 0:
+            slaveaddressport = slave.get_interface().get_port_by_type(
+                bus.sig_name("slave", "address"))
+            slavename_addr = slaveinstance.instancename + "_" +\
+                slaveaddressport.name
+
+        out = out + "\n"
+        out = out + ONETAB*3 + "if " + masteraddressname + "(" +\
+            str(int(mastersizeaddr-1)) + " downto " + str(slavesizeaddr + 1) +\
+            ')="' +\
+            sy.inttobin(slavebase_address,
+                        int(mastersizeaddr))[:-(slavesizeaddr + 1)] +\
+            '"' + " and " + masterstrobename + "='1' then\n"
+
+        out = out + ONETAB * 4 + chipselectname + " <= '1';\n"
+        out = out + ONETAB * 3 + "else\n"
+        out = out + ONETAB * 4 + chipselectname + " <= '0';\n"
+        out = out + ONETAB * 3 + "end if;\n"
+
+    out = out + "\n" + ONETAB * 2 + "end if;\n" +\
+        ONETAB + "end process decodeproc;\n\n"
+    return out
+
+
+def controlslave(masterinterface, intercon):
+    """ Connect controls signals for slaves
+    """
+
+    bus = masterinterface.bus
+    masterinstance = masterinterface.parent
+    masterinstancename = masterinstance.instancename
+    masterinterfacename = masterinterface.name
+    masterstrobename = masterinstancename + "_" +\
+        masterinterface.get_port_by_type(
+            bus.sig_name("master", "strobe")).name
+    mastercyclename = masterinstancename + "_" +\
+        masterinterface.get_port_by_type(
+            bus.sig_name("master", "cycle")).name
+
+    out = ONETAB + "-----------------------------\n"
+    out = out + ONETAB + "-- Control signals to slave\n"
+    out = out + ONETAB + "-----------------------------\n"
+
+    for slave in masterinterface.slaves:
+        slaveinstance = slave.get_instance()
+        slaveinterface = slave.get_interface()
+        slaveinstancename = slave.instancename
+        slavestrobename = slaveinstancename + "_" +\
+            slaveinterface.get_port_by_type(
+                bus.sig_name("slave", "strobe")).name
+        slavecyclename = slaveinstancename + "_" +\
+            slaveinterface.get_port_by_type(
+                bus.sig_name("slave", "cycle")).name
+
+        chipselectname = slaveinstancename + "_" +\
+            slaveinterface.name + "_cs"
+
+        out = out + "\n" + ONETAB + "-- for " + slaveinstancename + "\n"
+        # strobe
+        out = out + ONETAB + slavestrobename + " <= (" +\
+            masterstrobename + " and " + chipselectname + " );\n"
+        # cycle
+        out = out + ONETAB + slavecyclename + " <= (" +\
+            mastercyclename + " and " + chipselectname + " );\n"
+
+        # write connection if read/write, read or write
+        try:
+            datainname = slaveinstancename + "_" +\
+                slaveinterface.get_port_by_type(
+                    bus.sig_name("slave", "datain")).name
+        except PodError:
+            datainname = None
+
+        try:
+            dataoutname = slaveinstancename + "_" +\
+                slaveinterface.get_port_by_type(
+                    bus.sig_name("slave", "dataout")).name
+        except PodError:
+            dataoutname = None
+
+        if datainname and dataoutname:
+            # write
+            out = out + ONETAB +\
+                slaveinstancename + "_" +\
+                slaveinterface.get_port_by_type(
+                    bus.sig_name("slave", "write")).name +\
+                " <= (" + masterinstancename + "_" + \
+                masterinterface.get_port_by_type(
+                    bus.sig_name("master", "write")).name + \
+                " and " + chipselectname + " );\n"
+        elif datainname:
+            # write
+            out = out + ONETAB +\
+                slaveinstancename + "_" +\
+                slaveinterface.get_port_by_type(
+                    bus.sig_name("slave", "write")).name +\
+                " <= '1';\n"
+        elif dataoutname:
+            # write
+            out = out + ONETAB +\
+                slaveinstancename + "_" +\
+                slaveinterface.get_port_by_type(
+                    bus.sig_name("slave", "write")).name +\
+                " <= '0';\n"
+        if datainname:
+                out = out + ONETAB + slaveinstancename + "_" +\
+                    slaveinterface.get_port_by_type(
+                        bus.sig_name("slave", "datain")).name + \
+                    " <= writedata" + slaveinterface.data_size + \
+                    "_s when (" + masterinstancename + "_" +\
+                    masterinterface.get_port_by_type(
+                        bus.sig_name("master", "write")).name +\
+                    " and " + chipselectname +\
+                    " ) = '1' else (others => '0');" + "\n"
+    return out
+
+
+def controlmaster(masterinterface, intercon):
+    bus = masterinterface.bus
+    masterinstance = masterinterface.parent
+    masterinstancename = masterinstance.instancename
+    masterinterfacename = masterinterface.name
+
+    out = "\n\n" + ONETAB + "-------------------------------\n"
+    out = out + ONETAB + "-- Control signal for master --\n"
+    out = out + ONETAB + "-------------------------------\n"
+
+    out = out + ONETAB + masterinstance.instancename + "_"
+    out = out + masterinterface.get_port_by_type(
+        bus.sig_name("master", "datain")).name
+    out = out + " <= "
+    # READDATA
+    for slave in masterinterface.slaves:
+        slaveinstance = slave.get_instance()
+        slaveinterface = slave.get_interface()
+        slaveinterfacename = slaveinterface.name
+        slaveinstancename = slave.instancename
+        try:
+            dataoutname = slaveinstancename + "_readdata_s"
+            out = out + " " + dataoutname
+            out = out + " when " + slaveinstancename + "_" +\
+                slaveinterfacename + "_cs='1' else\n"
+            out = out + ONETAB * 9 + "  "
+        except PodError, e:
+            pass
+    out = out + " (others => '0');\n"
+
+    # ACK
+    out = out + ONETAB + masterinstance.instancename + "_"
+    out = out + masterinterface.get_port_by_type(
+        bus.sig_name("master", "ack")).name
+    out = out + " <= "
+    count = 0
+    if masterinterface.slaves:
+        for slave in masterinterface.slaves:
+            slaveinstance = slave.get_instance()
+            slaveinterface = slave.get_interface()
+            slaveinterfacename = slaveinterface.name
+            slaveinstancename = slave.instancename
+            if count == 0:
+                out = out + " "
+                count = 1
+            else:
+                out = out + "\n" + ONETAB * 9 + "or \n"
+                out = out + ONETAB * 8
+            out = out + "(" + slaveinstancename + "_" +\
+                slaveinterface.get_port_by_type(
+                    bus.sig_name("slave", "ack")).name +\
+                " and " + slaveinstancename + "_" + slaveinterfacename + "_cs)"
+    else:
+        out = out + "'0'"
+    out = out + ";\n"
+    return out
+
+
+def selectWrite(masterinterface, intercon):
+    master_size = int(masterinterface.data_size)
+    bus = masterinterface.bus
+    byte_en = masterinterface.get_port_by_type("BYE")
+    byte_en_name = masterinterface.parent.instancename + "_" + byte_en.name
+    byte_en_size = int(byte_en.real_size)
+    out = ""
+
+    for slave in masterinterface.slaves:
+        interface = slave.get_interface()
+        slave_bus_name = slave.get_instance().instancename + "_" + \
+            interface.get_port_by_type(bus.sig_name("slave", "dataout")).name
+        data_size = int(interface.data_size)
+        out = out + ONETAB + slave.instancename + "_readdata_s <= "
+        if int(data_size) == int(master_size):
+            out = out + slave_bus_name
+        else:
+            nb_byte = data_size / 8
+            mask = pow(2, nb_byte)-1
+            bitsize = master_size / data_size
+            for i in range(bitsize):
+                min_pos = i * data_size
+                val = bin(int(mask * pow(2, nb_byte*i)))[2:]
+                if i < bitsize - 1:
+                    out = out + "(" + str(master_size-1) + \
+                        " downto " + str(min_pos + data_size) + " => '0') & "
+                out = out + slave_bus_name + " "
+                if i != 0:
+                    out = out + "& (" + str(min_pos-1) + " downto 0 => '0')"
+                if i < bitsize - 1:
+                    out = out + " when " + byte_en_name + ' = "' + \
+                        val.zfill(byte_en_size) + '" else\n' + 2 * ONETAB
+        out = out + ";\n\n"
+
+    return out
+
+
+def architectureFoot(intercon):
+        """ Write foot architecture code
+        """
+        out = "\nend architecture " + intercon.name + "_1;\n"
+        return out
+
+
+def generate_intercon(masterinterface, intercon):
+    """Generate intercon VHDL code for wishbone16 bus
+    """
+    masterinstance = masterinterface.parent
+    project = masterinstance.parent
+
+    # comment and header
+    VHDLcode = header(SETTINGS.author, intercon)
+    # entity
+    VHDLcode = VHDLcode + entity(intercon)
+    VHDLcode = VHDLcode + architectureHead(masterinterface, intercon)
+    VHDLcode = VHDLcode + genCaseByteEnable(masterinterface)
+    listslave = masterinterface.slaves
+    listinterfacesyscon = []
+    for slaveinstance in [slave.get_instance() for slave in listslave]:
+        listinterfacesyscon.append(slaveinstance.get_one_syscon())
+    listinterfacesyscon.append(masterinstance.get_one_syscon())
+
+    # Clock and Reset connection
+    VHDLcode = VHDLcode + connectClockandReset(masterinterface,
+                                               intercon)
+
+    # address decoding
+    VHDLcode = VHDLcode + addressdecoding(masterinterface,
+                                          masterinstance, intercon)
+
+    # controls slaves
+    VHDLcode = VHDLcode + controlslave(masterinterface, intercon)
+    # controls master
+    VHDLcode = VHDLcode + controlmaster(masterinterface, intercon)
+    # readdata mux
+    VHDLcode = VHDLcode + selectWrite(masterinterface, intercon)
+    # Foot
+    VHDLcode = VHDLcode + architectureFoot(intercon)
+
+    # saving
+    if not sy.dir_exist(SETTINGS.projectpath +
+                        COMPONENTSPATH + "/" +
+                        intercon.instancename + "/" + HDLDIR):
+        sy.mkdir(SETTINGS.projectpath +
+                 COMPONENTSPATH + "/" +
+                 intercon.instancename + "/" + HDLDIR)
+    afile = open(SETTINGS.projectpath + COMPONENTSPATH + "/" +
+                 intercon.instancename +
+                 "/" + HDLDIR + "/" + intercon.instancename + VHDLEXT,
+                 "w")
+    afile.write(VHDLcode)
+    afile.close()
+    # hdl file path
+    hdl = HdlFile(intercon,
+                  filename=intercon.instancename + VHDLEXT,
+                  istop=1, scope="both")
+    intercon.add_hdl_file(hdl)
+    return VHDLcode

--- a/src/busses/wishboneExt/wishboneExt.py
+++ b/src/busses/wishboneExt/wishboneExt.py
@@ -114,9 +114,11 @@ def architectureHead(masterinterface, intercon):
 
     # create new data signal
     for size in data_size:
+        # all writedata used with mux to adapt size
         archead = archead + ONETAB + "signal " +\
             "%-20s" % ("writedata" + str(size) + "_s") + \
             " : std_logic_vector(" + str(size-1) + " downto 0);\n"
+    # local readdata with LSB added
     archead = archead + ONETAB + "signal " + \
         "%-20s" % ("wbm_address_s") + \
         " : std_logic_vector(" + addr_size + " downto 0);\n"
@@ -126,6 +128,7 @@ def architectureHead(masterinterface, intercon):
             "%-20s" % (slave.instancename + "_" +
                        slave.interfacename + "_cs") +\
             " : std_logic := '0' ;\n"
+        # slave readdata reconstruct to match master readdata
         archead = archead + ONETAB + "signal " +\
             "%-20s" % (slave.instancename + "_readdata_s") + \
             " : std_logic_vector(" + str(data_size) + " downto 0);\n"

--- a/src/busses/wishboneExt/wishboneExt.py
+++ b/src/busses/wishboneExt/wishboneExt.py
@@ -494,7 +494,8 @@ def selectWrite(masterinterface, intercon):
         interface = slave.get_interface()
         try:
             slave_bus_name = slave.get_instance().instancename + "_" + \
-                interface.get_port_by_type(bus.sig_name("slave", "dataout")).name
+                interface.get_port_by_type(
+                    bus.sig_name("slave", "dataout")).name
         except PodError:
             continue
 

--- a/src/busses/wishboneExt/wishboneExt.xml
+++ b/src/busses/wishboneExt/wishboneExt.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<bus name="wishboneExt" version="1.0" datasize="16">
+    <description></description>
+    <class name="WBM" type="master">
+        <type name="RST" type="reset" dir="out" />
+        <type name="CLK" type="clock" dir="out" />
+        <type name="ADR" type="address"   dir="out" />
+        <type name="BUE" type="busen"   dir="out" />
+        <type name="BYE" type="byen"   dir="out" />
+        <type name="RW" type="rwn"   dir="out" />
+        <type name="DAT_I" type="datain"  dir="in" />
+        <type name="DAT_O" type="dataout" dir="out" />
+        <type name="ACK" type="ack"    dir="in" />
+        <type name="irq" type="irq"    dir="in" />
+        <type name="WE"  type="write"  dir="out" />
+        <type name="SEL" type="select" dir="out" />
+        <type name="CYC" type="cycle"  dir="out" />
+        <type name="STB" type="strobe" dir="out" />
+    </class>
+    <class name="WBS" type="slave">
+        <type name="RST"   type="reset"   dir="in" />
+        <type name="CLK"   type="clock"   dir="in" />
+        <type name="ADR"   type="address" dir="in" />
+        <type name="DAT_I" type="datain"  dir="in" />
+        <type name="DAT_O" type="dataout" dir="out" />
+        <type name="WE"  type="write"  dir="in" />
+        <type name="SEL" type="select" dir="in" />
+        <type name="ACK" type="ack"    dir="out" />
+        <type name="CYC" type="cycle"  dir="in" />
+        <type name="STB" type="strobe" dir="in" />
+    </class>
+</bus>

--- a/src/busses/wishboneExt/wishboneExt.xml
+++ b/src/busses/wishboneExt/wishboneExt.xml
@@ -5,15 +5,12 @@
         <type name="RST" type="reset" dir="out" />
         <type name="CLK" type="clock" dir="out" />
         <type name="ADR" type="address"   dir="out" />
-        <type name="BUE" type="busen"   dir="out" />
-        <type name="BYE" type="byen"   dir="out" />
-        <type name="RW" type="rwn"   dir="out" />
+        <type name="BYE" type="byteen"   dir="out" />
         <type name="DAT_I" type="datain"  dir="in" />
         <type name="DAT_O" type="dataout" dir="out" />
-        <type name="ACK" type="ack"    dir="in" />
-        <type name="irq" type="irq"    dir="in" />
         <type name="WE"  type="write"  dir="out" />
         <type name="SEL" type="select" dir="out" />
+        <type name="ACK" type="ack"    dir="in" />
         <type name="CYC" type="cycle"  dir="out" />
         <type name="STB" type="strobe" dir="out" />
     </class>
@@ -23,6 +20,7 @@
         <type name="ADR"   type="address" dir="in" />
         <type name="DAT_I" type="datain"  dir="in" />
         <type name="DAT_O" type="dataout" dir="out" />
+        <type name="BYE" type="byteen"   dir="in" />
         <type name="WE"  type="write"  dir="in" />
         <type name="SEL" type="select" dir="in" />
         <type name="ACK" type="ack"    dir="out" />


### PR DESCRIPTION


This patch provides a more generic implementation of wishbone address decoding.
It adds :

    byte enable signal to allows read/write size lesser than readdata/writedata size;
    ability to have master and slave with different data size (only if slave has bus size <= master bus size); It allows :
    address reconstruction according to byte enable and address size;
    slave's writedata reconstruction based on byte enable and master's writedata
    master's readdata reconstruction based on byte enable, address and slave's readdata size.

