### PR TITLE
supress SETTINGS.active_project (part1)

### DIFF
--- a/src/bin/code/intercon.py
+++ b/src/bin/code/intercon.py
@@ -37,13 +37,13 @@ DISPLAY = Display()
 class Intercon(Component):
     """ Generate Intercon component """
 
-    def __init__(self, masterinterface):
+    def __init__(self, parent, masterinterface):
         """ Init fonction
         """
         masterinstancename = masterinterface.parent.instancename
         masterinterfacename = masterinterface.name
 
-        Component.__init__(self)
+        Component.__init__(self, parent)
         self.interfaceslist = []
         self.add_node(nodename="component")
 

--- a/src/bin/code/vhdl/topvhdl.py
+++ b/src/bin/code/vhdl/topvhdl.py
@@ -47,8 +47,7 @@ class TopVHDL(TopGen):
     def __init__(self, project):
         TopGen.__init__(self, project)
 
-    @classmethod
-    def header(cls):
+    def header(self):
         """ return vhdl header
         """
         header = open(SETTINGS.path + TEMPLATESPATH +
@@ -57,10 +56,10 @@ class TopVHDL(TopGen):
         header = header.replace("$tpl:date$", str(datetime.date.today()))
         header = header.replace("$tpl:filename$",
                                 "Top_" +
-                                SETTINGS.active_project.name + ".vhd")
+                                self.project.name + ".vhd")
         header = header.replace(
             "$tpl:abstract$",
-            SETTINGS.active_project.description)
+            self.project.description)
         return header
 
     def entity(self, entityname, portlist):

--- a/src/bin/commandline/drivercli.py
+++ b/src/bin/commandline/drivercli.py
@@ -40,10 +40,9 @@ class DriverCli(BaseCli):
     """ Manage driver command line environment
     """
 
-    def __init__(self, parent):
-        BaseCli.__init__(self, parent)
-        self.driver = SETTINGS.active_project.driver
-        self.project = SETTINGS.active_project
+    def __init__(self, parent, project=None):
+        BaseCli.__init__(self, parent, project)
+        self.driver = self._project.driver
 
     def testIfToolChainSelected(self):
         """ test if toolchain selected """
@@ -150,20 +149,20 @@ select operating system to generate drivers
             print error
             return
         if line.strip() == "":
-            if len(SETTINGS.active_project.get_driver_toolchains()) == 1:
-                SETTINGS.active_project.driver_toolchain =\
-                    SETTINGS.active_project.get_driver_toolchains()[0]
+            if len(self._project.get_driver_toolchains()) == 1:
+                self._project.driver_toolchain =\
+                    self._project.get_driver_toolchains()[0]
             else:
-                if SETTINGS.active_project.driver_toolchain is None:
+                if self._project.driver_toolchain is None:
                     print "Choose a toolchain\n"
                     for toolchain in \
-                            SETTINGS.active_project.get_driver_toolchains():
+                            self._project.get_driver_toolchains():
                         print toolchain
                     return
         else:
             try:
-                SETTINGS.active_project.driver_toolchain = line
+                self._project.driver_toolchain = line
             except PodError, error:
                 print error
                 return
-        self.driver = SETTINGS.active_project.driver
+        self.driver = self._project.driver

--- a/src/bin/commandline/projectcli.py
+++ b/src/bin/commandline/projectcli.py
@@ -74,7 +74,7 @@ synthesis commands
             print(str(error))
             return
 
-        cli = SynthesisCli(self)
+        cli = SynthesisCli(self, self._project)
         cli.setPrompt("synthesis")
         arg = str(arg)
         if len(arg) > 0:
@@ -98,7 +98,7 @@ Simulation generation environment
             return
 
         # test if only one toolchain for simulation in library
-        cli = SimulationCli(self)
+        cli = SimulationCli(self, self._project)
         cli.setPrompt("simulation")
         line = str(line)
         if len(line) > 0:
@@ -122,7 +122,7 @@ Driver generation environment
             return
 
         # test if only one toolchain for simulation in library
-        cli = DriverCli(self)
+        cli = DriverCli(self, self._project)
         cli.setPrompt("driver")
         line = str(line)
         if len(line) > 0:

--- a/src/bin/commandline/simulationcli.py
+++ b/src/bin/commandline/simulationcli.py
@@ -40,8 +40,8 @@ class SimulationCli(BaseCli):
     """ Commands line for simulation environment
     """
 
-    def __init__(self, parent=None):
-        BaseCli.__init__(self, parent)
+    def __init__(self, parent=None, project=None):
+        BaseCli.__init__(self, parent, project)
 
     def complete_selecttoolchain(self, text, line, begidx, endidx):
         """ selecttoolchain command completion """
@@ -65,20 +65,20 @@ select toolchain used for simulation
             return
 
         if line.strip() == "":
-            if len(SETTINGS.active_project.get_simulation_toolchains()) == 1:
-                SETTINGS.active_project.simulation_toolchain =\
-                    SETTINGS.active_project.get_simulation_toolchains()[0]
+            if len(self._project.get_simulation_toolchains()) == 1:
+                self._project.simulation_toolchain =\
+                    self._project.get_simulation_toolchains()[0]
             else:
-                if SETTINGS.active_project.simulation_toolchain is None:
+                if self._project.simulation_toolchain is None:
                     print "Choose a toolchain\n"
-                    project = SETTINGS.active_project
+                    project = self._project
                     for toolchain in \
                             project.get_simulation_toolchains():
                         print(str(toolchain))
                     return
         else:
             try:
-                SETTINGS.active_project.simulation_toolchain = line
+                self._project.simulation_toolchain = line
             except PodError, error:
                 print(str(error))
                 return
@@ -94,19 +94,19 @@ Make projects files for simulation (makefile and testbench sources)
             except PodError, error:
                 print(str(error))
                 return
-        elif SETTINGS.active_project.simulation is None:
+        elif self._project.simulation is None:
             print PodError("Simulation toolchain must be selected before")
             return
 
-        if SETTINGS.active_project.simulation_toolchain is None:
+        if self._project.simulation_toolchain is None:
             print PodError("Choose a toolchain before", 0)
             for toolchain in \
-                    SETTINGS.active_project.get_simulation_toolchains():
+                    self._project.get_simulation_toolchains():
                 print(str(toolchain.name))
             return
         try:
-            filename = SETTINGS.active_project.simulation.generate_template()
-            filename = SETTINGS.active_project.simulation.generate_makefile()
+            filename = self._project.simulation.generate_template()
+            filename = self._project.simulation.generate_makefile()
         except PodError, error:
             print(str(error))
             return

--- a/src/bin/commandline/synthesiscli.py
+++ b/src/bin/commandline/synthesiscli.py
@@ -41,8 +41,8 @@ DISPLAY = Display()
 class SynthesisCli(BaseCli):
     """ Manage synthesis command line environment """
 
-    def __init__(self, parent):
-        BaseCli.__init__(self, parent)
+    def __init__(self, parent, project=None):
+        BaseCli.__init__(self, parent, project)
 
     def complete_selecttoolchain(self, text, line, begidx, endidx):
         """ Select toolchain completion """
@@ -68,19 +68,19 @@ select toolchain used for simulation
             return
 
         if line.strip() == "":
-            if len(SETTINGS.active_project.get_synthesis_toolchains()) == 1:
-                SETTINGS.active_project.synthesis_toolchain =\
-                    SETTINGS.active_project.get_synthesis_toolchains()[0]
+            if len(self._project.get_synthesis_toolchains()) == 1:
+                self._project.synthesis_toolchain =\
+                    self._project.get_synthesis_toolchains()[0]
             else:
-                if SETTINGS.active_project.synthesis_toolchain is None:
+                if self._project.synthesis_toolchain is None:
                     print("Choose a toolchain\n")
                     for toolchain in\
-                            SETTINGS.active_project.get_synthesis_toolchains():
+                            self._project.get_synthesis_toolchains():
                         print(str(toolchain))
                     return
         else:
             try:
-                SETTINGS.active_project.synthesis_toolchain = line
+                self._project.synthesis_toolchain = line
             except PodError, error:
                 print(str(error))
                 return
@@ -114,31 +114,30 @@ generate the project for synthesis tool
             except PodError, error:
                 print(str(error))
                 return
-        elif SETTINGS.active_project.synthesis is None:
+        elif self._project.synthesis is None:
             print(str(PodError("Toolchain must be selected before")))
             return
 
         # generate project
         try:
-            SETTINGS.active_project.synthesis.generate_project()
+            self._project.synthesis.generate_project()
             print(str(DISPLAY))
-            SETTINGS.active_project.synthesis.generate_pinout(None)
+            self._project.synthesis.generate_pinout(None)
             print(str(DISPLAY))
-            SETTINGS.active_project.synthesis.generate_tcl(None)
+            self._project.synthesis.generate_tcl(None)
         except PodError, error:
             print(str(error))
             return
         print(str(DISPLAY))
 
-    @classmethod
-    def do_generatetcl(cls, line):
+    def do_generatetcl(self, line):
         """\
 Usage : generatetcl [filename]
 Made a tcl script for synthesis,tools supported are:
 ise
         """
 
-        if SETTINGS.active_project.synthesis is None:
+        if self._project.synthesis is None:
             print PodError("Select toolchain before")
             return
         if line.strip() != "":
@@ -147,7 +146,7 @@ ise
         else:
             filename = None
         try:
-            SETTINGS.active_project.synthesis.generate_tcl(filename)
+            self._project.synthesis.generate_tcl(filename)
         except PodError, error:
             print(str(error))
             return
@@ -159,7 +158,7 @@ Usage : generatepinout [filename]
 generate ucf file, tool supported are :
 ise
         """
-        if SETTINGS.active_project.synthesis is None:
+        if self._project.synthesis is None:
             print(str(PodError("Select toolchain before")))
             return
         if line.strip() != "":
@@ -168,7 +167,7 @@ ise
         else:
             filename = None
         try:
-            SETTINGS.active_project.synthesis.generate_pinout(filename)
+            self._project.synthesis.generate_pinout(filename)
         except PodError, error:
             print(str(error))
             return
@@ -180,11 +179,11 @@ Usage : generatebitstream
 generate the bitstream for fpga configuration
         """
         del line
-        if SETTINGS.active_project.synthesis is None:
+        if self._project.synthesis is None:
             print PodError("Select toolchain before")
             return
         try:
-            SETTINGS.active_project.synthesis.generate_bitstream()
+            self._project.synthesis.generate_bitstream()
         except PodError, error:
             print(str(error))
             return
@@ -216,7 +215,7 @@ set IO standard value
         io_name = arg[0]
         standard_value = arg[1]
         try:
-            SETTINGS.active_project.get_io(io_name).standard = standard_value
+            self._project.get_io(io_name).standard = standard_value
         except PodError, error:
             print(str(DISPLAY))
             print(str(error))
@@ -247,7 +246,7 @@ get IO standard value
         arg = line.split(' ')
         io_name = arg[0]
         try:
-            print SETTINGS.active_project.get_io(io_name).standard
+            print self._project.get_io(io_name).standard
         except PodError, error:
             print DISPLAY
             print error
@@ -280,7 +279,7 @@ set IO standard value
         io_name = arg[0]
         port_option_value = arg[1]
         try:
-            SETTINGS.active_project.get_io(
+            self._project.get_io(
                 io_name).port_option = port_option_value
         except PodError, error:
             print(str(DISPLAY))
@@ -312,7 +311,7 @@ get IO Port option value
         arg = line.split(' ')
         io_name = arg[0]
         try:
-            print SETTINGS.active_project.get_io(io_name).port_option
+            print self._project.get_io(io_name).port_option
         except PodError, error:
             print DISPLAY
             print error
@@ -345,7 +344,7 @@ set IO drive value
         io_name = arg[0]
         drive_value = arg[1]
         try:
-            SETTINGS.active_project.get_io(io_name).drive = drive_value
+            self._project.get_io(io_name).drive = drive_value
         except PodError, error:
             print(str(DISPLAY))
             print(str(error))
@@ -376,7 +375,7 @@ get IO drive value
         arg = line.split(' ')
         io_name = arg[0]
         try:
-            print SETTINGS.active_project.get_io(io_name).drive
+            print self._project.get_io(io_name).drive
         except PodError, error:
             print(str(DISPLAY))
             print(str(error))
@@ -409,7 +408,7 @@ Set fpga attributes
         att_name = arg[0]
         att_value = arg[1]
         try:
-            platform = SETTINGS.active_project.platform
+            platform = self._project.platform
             platform.set_attr(att_name, att_value, "fpga")
         except PodError, error:
             print(str(DISPLAY))
@@ -442,7 +441,7 @@ get fpga attributes values
         arg = line.split(' ')
         att_name = arg[0]
         try:
-            platform = SETTINGS.active_project.platform
+            platform = self._project.platform
             print(str(platform.get_attr_value(att_name, "fpga")))
         except PodError, error:
             print(str(DISPLAY))

--- a/src/bin/core/component.py
+++ b/src/bin/core/component.py
@@ -43,7 +43,7 @@ class Component(WrapperXml):
 
     """
 
-    def __init__(self, node=None, afile=None):
+    def __init__(self, parent, node=None, afile=None):
         """ Init Component,
             __init__(self)
         """
@@ -63,7 +63,7 @@ class Component(WrapperXml):
         self._constraintslist = []
 
         # Project that use the component
-        self.parent = SETTINGS.active_project
+        self.parent = parent
         self.void = 0
 
     def load_new_instance(self, libraryname, componentname,

--- a/src/bin/core/component.py
+++ b/src/bin/core/component.py
@@ -322,6 +322,10 @@ class Component(WrapperXml):
         if dirname == "inout":
             return "inout"
 
+    def get_instance(self, instancename):
+        """ get the parent instance of this interface """
+        return self.parent.get_instance(instancename)
+
     def del_pin(self, instancedest, interfacedest=None, portdest=None,
                 pindest=None, interfacesource=None, portsource=None,
                 pinsource=None):

--- a/src/bin/core/interface.py
+++ b/src/bin/core/interface.py
@@ -339,6 +339,10 @@ class Interface(WrapperXml):
         instanceslave.get_generic(genericname="id").value =\
             str(interfaceslave.unique_id)
 
+    def get_instance(self, instancename):
+        """ get the parent instance of this interface """
+        return self.parent.get_instance(instancename)
+
     @property
     def unique_id(self):
         """ Get the Identifiant number"""

--- a/src/bin/core/interface.py
+++ b/src/bin/core/interface.py
@@ -46,7 +46,7 @@ class Interface(WrapperXml):
             __init__(self,parent,nodestring)
         """
 
-        self.parent = parent
+        self._parent = parent
 
         if "name" in keys:
             WrapperXml.__init__(self, nodename="interface")
@@ -380,6 +380,16 @@ class Interface(WrapperXml):
             if register.name == registername:
                 return register
         raise PodError("No register with name " + registername, 0)
+
+    @property
+    def parent(self):
+        """ return parent instance """
+        return self._parent
+
+    @parent.setter
+    def parent(self, parent):
+        """ set parent instance """
+        self._parent = parent
 
     @property
     def registers(self):

--- a/src/bin/core/pin.py
+++ b/src/bin/core/pin.py
@@ -225,9 +225,9 @@ class Pin(WrapperXml):
 
             if instance_dest.is_platform() is True:
                 pin_dest = instance_dest.get_interface(
-                        connection["interface_dest"]).get_port(
-                            connection["port_dest"]).get_pin(
-                                connection["pin_dest"])
+                    connection["interface_dest"]).get_port(
+                        connection["port_dest"]).get_pin(
+                            connection["pin_dest"])
                 pindest_list.append(pin_dest)
         self.del_connections_forces()
         for pin_dest in pindest_list:

--- a/src/bin/core/pin.py
+++ b/src/bin/core/pin.py
@@ -90,7 +90,7 @@ class Pin(WrapperXml):
         """ Delete all connection from or to this pin """
         for connection in self.connections:
             try:
-                instance_dest = SETTINGS.active_project.get_instance(
+                instance_dest = self.parent.get_instance(
                     connection["instance_dest"])
                 interface_dest =\
                     instance_dest.get_interface(connection["interface_dest"])
@@ -218,17 +218,17 @@ class Pin(WrapperXml):
         """ connect all platform connection, if connection is not
             for this platform, delete it.
         """
-        project = SETTINGS.active_project
         pindest_list = []
-        if project.platform_name is not None:
-            for connection in self.connections:
-                if connection["instance_dest"] == project.platform_name:
-                    pin_dest = project.get_instance(
-                        connection["instance_dest"]).get_interface(
-                            connection["interface_dest"]).get_port(
-                                connection["port_dest"]).get_pin(
-                                    connection["pin_dest"])
-                    pindest_list.append(pin_dest)
+        for connection in self.connections:
+            instance_dest = self.parent.get_instance(
+                connection["instance_dest"])
+
+            if instance_dest.is_platform() is True:
+                pin_dest = instance_dest.get_interface(
+                        connection["interface_dest"]).get_port(
+                            connection["port_dest"]).get_pin(
+                                connection["pin_dest"])
+                pindest_list.append(pin_dest)
         self.del_connections_forces()
         for pin_dest in pindest_list:
             self.connect_pin(pin_dest)

--- a/src/bin/core/platform.py
+++ b/src/bin/core/platform.py
@@ -45,9 +45,9 @@ class Platform(Component):
             __init__(self, parent, file)
         """
         if "node" in keys:
-            Component.__init__(self, node=keys["node"])
+            Component.__init__(self, parent, node=keys["node"])
         elif "file" in keys:
-            Component.__init__(self, afile=keys["file"])
+            Component.__init__(self, parent, afile=keys["file"])
         else:
             raise PodError("Keys unknown in Platform constructor", 0)
 

--- a/src/bin/core/port.py
+++ b/src/bin/core/port.py
@@ -345,6 +345,9 @@ class Port(WrapperXml):
         for pin in self.pins:
             pin.autoconnect_pin()
 
+    def get_instance(self, instancename):
+        return self.parent.get_instance(instancename)
+
     @property
     def dest_port(self):
         """ get destination port connected to this port

--- a/src/bin/core/project.py
+++ b/src/bin/core/project.py
@@ -125,7 +125,7 @@ class Project(WrapperXml):
         if(components):
             for node in components.get_nodes("component"):
                 if node.get_attr_value("platform") is None:
-                    comp = Component()
+                    comp = Component(self)
                 else:
                     comp = Platform(self, node=self.get_node("platform"))
                 try:
@@ -369,7 +369,7 @@ class Project(WrapperXml):
             if (componentname == instancename):
                 raise PodError("Instance name can't be the" +
                                "same as component name", 0)
-            comp = Component()
+            comp = Component(self)
             comp.load_new_instance(libraryname, componentname,
                                    componentversion, instancename)
             comp.num = str(len(
@@ -660,7 +660,7 @@ class Project(WrapperXml):
 
         instance = self.get_instance(interfacedict["instance"])
         interface = instance.get_interface(interfacedict["interface"])
-        intercon = Intercon(interface)
+        intercon = Intercon(self, interface)
         self.add_instance(component=intercon)
         self.save()
 

--- a/src/bin/core/slave.py
+++ b/src/bin/core/slave.py
@@ -78,7 +78,7 @@ class Slave(WrapperXml):
 
     def get_instance(self):
         """ get the parent instance of this slave interface """
-        return SETTINGS.active_project.get_instance(self.instancename)
+        return self.parent.get_instance(self.instancename)
 
     def get_interface(self):
         """ get the parent interface of this slave interface """

--- a/src/bin/utils/basecli.py
+++ b/src/bin/utils/basecli.py
@@ -39,10 +39,11 @@ class BaseCli(cmd.Cmd):
     default_extension = 'txt'
     old_completer = None
 
-    def __init__(self, parent=None, *args, **kwargs):
+    def __init__(self, parent=None, project=None, *args, **kwargs):
         cmd.Cmd.__init__(self, *args, **kwargs)
         self.parent = parent
         SETTINGS.history = SETTINGS.history[:-1]
+        self._project = project
 
         if parent is None:
             self.setPrompt(BASE_PROMPT)
@@ -348,7 +349,7 @@ fpga_attributes    : give list of fpga attributes in platform
             if listargs[0][0] == "masterinstancename" or\
                listargs[0][0] == "slaveinstancename" or\
                listargs[0][0] == "instancename":
-                instance = SETTINGS.active_project.get_instance(listargs[0][1])
+                instance = self._project.get_instance(listargs[0][1])
                 instancename = instance.instancename
             elif listargs[0][0] == "platformlib":
                 platformlib = listargs[0][1]
@@ -376,14 +377,14 @@ fpga_attributes    : give list of fpga attributes in platform
         if subargt == "masterinstancename":
             return [interface.parent.instancename
                     for interface in
-                    SETTINGS.active_project.interfaces_master]
+                    self._project.interfaces_master]
         elif subargt == "slaveinstancename":
             return [interface.parent.instancename
                     for interface in
-                    SETTINGS.active_project.interfaces_slave]
+                    self._project.interfaces_slave]
         elif subargt == "instancename":
             return [instance.instancename
-                    for instance in SETTINGS.active_project.instances]
+                    for instance in self._project.instances]
         elif subargt == "interfacename":
             return ["" + instancename + "." + interface.name
                     for interface in instance.interfaces]
@@ -401,7 +402,7 @@ fpga_attributes    : give list of fpga attributes in platform
                     "." + portname + "." + str(i)
                     for i in range(int(port.size))]
         elif subargt == "libraryname":
-            arglist = SETTINGS.active_project.library.libraries
+            arglist = self._project.library.libraries
             return arglist
 
         elif subargt == "platformlib":
@@ -411,7 +412,7 @@ fpga_attributes    : give list of fpga attributes in platform
         elif subargt == "forcename":
             arglist = ["" + port.name
                        for port in
-                       SETTINGS.active_project.platform.platform_ports]
+                       self._project.platform.platform_ports]
             return arglist
         elif subargt == "forcestate":
             return ["gnd", "vcc", "undef"]
@@ -434,18 +435,18 @@ fpga_attributes    : give list of fpga attributes in platform
                 # libraryname = SETTINGS.active_library.lib_name
                 # return [componentname + "." + version
                 #         for version in
-                #         SETTINGS.active_project.get_components_versions(
+                #         self._project.get_components_versions(
                 #             libraryname, componentname)]
             return [libraryname + "." + componentname + "." + comp
                     for comp in
-                    SETTINGS.active_project.get_components_versions(
+                    self._project.get_components_versions(
                         libraryname, componentname)]
 
         elif subargt == "platformname":
             if platformlib == "standard":
                 return ["standard." + name
                         for name in
-                        SETTINGS.active_project.availables_plat()]
+                        self._project.availables_plat()]
             else:
                 return [platformlib + "." + name
                         for name in
@@ -457,17 +458,17 @@ fpga_attributes    : give list of fpga attributes in platform
                     for generic in instance.generics]
 
         elif subargt == "simulationtoolchain":
-            return SETTINGS.active_project.get_simulation_toolchains()
+            return self._project.get_simulation_toolchains()
 
         elif subargt == "synthesistoolchain":
-            return SETTINGS.active_project.get_synthesis_toolchains()
+            return self._project.get_synthesis_toolchains()
         elif subargt == "drivertoolchain":
-            return SETTINGS.active_project.get_driver_toolchains()
+            return self._project.get_driver_toolchains()
         elif subargt == "IO_name":
             return [port.name for port in
-                    SETTINGS.active_project.get_ios()]
+                    self._project.get_ios()]
         elif subargt == "fpga_attributes":
-            platform = SETTINGS.active_project.platform
+            platform = self._project.platform
             return platform.get_attr_names("fpga")
         else:
             return []
@@ -520,7 +521,7 @@ fpga_attributes    : give list of fpga attributes in platform
 
     def isPlatformSelected(self):
         """ check if platform is selected, if not raise error """
-        SETTINGS.active_project.platform
+        self._project.platform
 
     def do_history(self, args):
         """ history


### PR DESCRIPTION
A global SETTINGS.active_project is used in many class. This is a not good practice and error prone. This serie of patches try to supress all call to SETTINGS.active_project and replace these by call to current project.