### PR TITLE
bin:toolchain:synthesis: error with retrieve absolute binary : use self.name instead of self.SYNTH_CMD

### DIFF
--- a/periphondemand/bin/toolchain/synthesis.py
+++ b/periphondemand/bin/toolchain/synthesis.py
@@ -290,7 +290,7 @@ class Synthesis(object):
         try:
             # try if .podrc exists
             return SETTINGS.get_synthesis_tool_command(
-                self.SYNTH_CMD)
+                self.name)
         except PodError:
             return self.SYNTH_CMD
 


### PR DESCRIPTION
…lf.name instead of self.SYNTH_CMD