### PR TITLE
Generate intercon only when slaves are connected

### DIFF
--- a/periphondemand/bin/code/topgen.py
+++ b/periphondemand/bin/code/topgen.py
@@ -457,15 +457,17 @@ class TopGen(object):
         """
         # checking if all intercons are done
         for masterinterface in self.project.interfaces_master:
-            try:
-                self.project.get_instance(
-                    masterinterface.parent.instancename +
-                    "_" +
-                    masterinterface.name +
-                    "_intercon")
-            except PodError as error:
-                raise PodError("Intercon missing, all intercon must be" +
-                               "generated before generate top.\n" + str(error))
+            if len(masterinterface.slaves) != 0:
+                try:
+                    self.project.get_instance(
+                        masterinterface.parent.instancename +
+                        "_" +
+                        masterinterface.name +
+                        "_intercon")
+                except PodError as error:
+                    raise PodError("Intercon missing, all intercon must be" +
+                                   " generated before generate top.\n" +
+                                   str(error))
 
         # header
         out = self.header()

--- a/periphondemand/bin/core/project.py
+++ b/periphondemand/bin/core/project.py
@@ -656,9 +656,14 @@ class Project(WrapperXml):
             pass
         else:
             self.del_instance(intercon.instancename)
-
         instance = self.get_instance(interfacedict["instance"])
         interface = instance.get_interface(interfacedict["interface"])
+
+        if len(interface.slaves) == 0:
+            DISPLAY.msg(interfacedict["instance"] + "." +
+                        interfacedict["interface"] +
+                        " not generated because no slaves")
+            return
         intercon = Intercon(self, interface)
         self.add_instance(component=intercon)
         self.save()


### PR DESCRIPTION
With some designs, candroutput or bus intercon are not needed and consequently the out part is left unconnected. In this situation the intercon is useless and may be not added. Some wrapper like apf6 or redpitaya provides master for both busses and ,with the current implementation, POD don't want to generate top because of missing intercon.

Vivado fail to build a design with intercon not connected (interpreted as a blackbox).
This serie of patch add test to generate intercon when mandatory.