### PR TITLE
interface,port: allow to have interface with optional ports

### DIFF
--- a/periphondemand/bin/core/port.py
+++ b/periphondemand/bin/core/port.py
@@ -113,6 +113,14 @@ class Port(WrapperXml):
             return False
 
     @property
+    def is_optional(self):
+        """ get port direction """
+        if self.get_attr_value("optional") == "true":
+            return True
+        else:
+            return False
+
+    @property
     def unconnected_value(self):
         """ Get unconnected value """
         try:


### PR DESCRIPTION
Some components, for genericity may have optional port to be usable in different type of chains.
This patch adds support for optional's ports.