### PR TITLE
setup.py: fixing version check

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,8 +37,8 @@ import sys
 sys.path.append("periphondemand/bin/")
 from version import VERSION
 
-import sysconfig
-if float(sysconfig.get_python_version()) < 3.4:
+(major, minor) = (sys.version_info.major, sys.version_info.minor)
+if major < 3 or (major == 3 and minor < 4):
     raise Exception("POD need python >= 3.4")
 
 


### PR DESCRIPTION
The use of `sysconfig.get_python_version()` and converting to a float results as this error:

```
python3 setup.py develop
Traceback (most recent call last):
  File "/somewhere/periphondemand/setup.py", line 44, in <module>
    raise Exception("POD need python >= 3.4")
Exception: POD need python >= 3.4
```
This is due to a wrong conversion string *3.10* becomes *3.1*

This PR replace sysconfig usage by `sys.version_info` to have access to *major* and *minor* as *int* and check if python version is lower than 3 or when major == 3 if minor is lower than 4.